### PR TITLE
Added update to resolve dependencies of sagemaker immersionday pip in…

### DIFF
--- a/sagemaker/sm-special-webinar/lab_3_pipeline/3.0.Setup-Environment.ipynb
+++ b/sagemaker/sm-special-webinar/lab_3_pipeline/3.0.Setup-Environment.ipynb
@@ -43,6 +43,17 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "outputs": [],
+   "source": [
+    "! pip install --upgrade sagemaker-data-insights"
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "e93e8563-0a24-4999-92f8-caa148d3cfe9",
    "metadata": {},
    "outputs": [],


### PR DESCRIPTION
Added update to resolve dependencies of sagemaker immersionday pip in event engine

*Issue #, if available:*
In event engine sagemaker immersionday selection, `!pip install --upgrade scikit-learn` was not updated. So, following error occurs in the preprocessing task.

`Encoding: Category Features
categorical_features: ['policy_state', 'policy_liability', 'customer_gender', 'customer_education', 'driver_relationship', 'incident_type', 'collision_type', 'incident_severity', 'authorities_contacted', 'police_report_available']
Traceback (most recent call last):
  File "src/preprocessing.py", line 153, in <module>
    processed_category_features = preprocess.transformers_[0][1].named_steps['onehot'].get_feature_names_out(categorical_features)
AttributeError: 'OneHotEncoder' object has no attribute 'get_feature_names_out'`

*Description of changes:*
Explicitly updating the dependent package sagemaker-data-insights to update scikit-learn can solve the error.

`!pip install --upgrade sagemaker-data-insights
`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
