### PR TITLE
Fix: korean input encoding error in Bedrock-Manus Deep Research

### DIFF
--- a/genai/aws-gen-ai-kr/20_applications/08_bedrock_manus/use_cases/01_deep_research_strands_sdk/.gitignore
+++ b/genai/aws-gen-ai-kr/20_applications/08_bedrock_manus/use_cases/01_deep_research_strands_sdk/.gitignore
@@ -1,0 +1,7 @@
+artifacts/
+assets/
+charts/
+
+__pycache__/
+.env
+.DS_Store


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

## 1/ Encoding error when answering to follow-up questions
- 한국어로 request 요청 후 follow-up questions 에 대한 답이 영어 캐릭터로 끝나면 오류가 발생 (?)
   - `1. 250만원 이내 2. 코딩 및 사무용 3. 없음 4. 네 5. Mac` --> Error
<img width="400" alt="image" src="https://github.com/user-attachments/assets/0a79c980-e77f-4fab-98a6-d8daeb46c93b" />

- 한국어로 끝났을 땐 정상 작동 
   - `1. 250만원 이내 2. 코딩 및 사무용 3. 없음 4. 네 5. 맥` --> 정상
<img width="400" alt="image" src="https://github.com/user-attachments/assets/935f7a6e-1965-487c-a3c2-7385b0fee82f" />

## 2/ Report not formatted issue when request is in korean 
<img width="822" alt="image" src="https://github.com/user-attachments/assets/658e7077-fc02-49a3-a248-13c65dc9860c" />


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
